### PR TITLE
Fix #50/user summary was too expensive

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -497,6 +497,9 @@ Beats Per Repeat (for rounds): <input type=text id=bpr></input>
     Disable latency measurement:
     <input type="checkbox" id="disableLatencyMeasurement">
   <br>
+    Enable mixing console:
+  <input type="checkbox" id="enableMixingConsole">
+  <br>
     Loopback mode:
     <select id=loopbackMode>
       <option value=none selected>None (default)</option>


### PR DESCRIPTION
JK: For large groups of users we don't want to compute the user summary, but we do still need the user summary for the people running sound, so add a checkbox that the person running sound can check and that will make us always send the full user summary to back the mixing console