### PR TITLE
Fix mark timing

### DIFF
--- a/html/audio-worklet.js
+++ b/html/audio-worklet.js
@@ -619,10 +619,13 @@ class Player extends AudioWorkletProcessor {
       });
       return;
     } else if (msg.type == "set_alarm") {
+      console.info("audio worklet setting alarm", msg);
       let cb = ()=>{ this.port.postMessage({type:"alarm",time:msg.time }) };
       if (msg.time > this.play_buffer.read_clock) {
+        console.info("alarm is in future");
         this.play_buffer.read_callbacks[msg.time] = cb;
       } else {
+        console.info("alarm is in past");
         cb();
       }
       return;

--- a/html/demo.js
+++ b/html/demo.js
@@ -253,7 +253,7 @@ function enableSpectatorMode() {
   start_singing();
 };
 
-window.latencyCalibrationGiveUp.addEventListener("click", enableSpectatorMode); 
+window.latencyCalibrationGiveUp.addEventListener("click", enableSpectatorMode);
 
 function persist(textFieldId) {
   const textField = document.getElementById(textFieldId);
@@ -650,7 +650,7 @@ function update_active_users(user_summary, server_sample_rate, imLeading, n_user
 
       const channelName = document.createElement("span");
       channelName.classList.add("channelName");
-      // set channelName 
+      // set channelName
 
       const channelVolume = document.createElement("span");
       channelVolume.classList.add("channelVolume");
@@ -662,7 +662,7 @@ function update_active_users(user_summary, server_sample_rate, imLeading, n_user
       const channelVolumeInput = document.createElement("input");
       channelVolumeInput.classList.add("channelVolumeInput");
       channelVolumeInput.type = "text";
-      
+
       channelVolumeInput.addEventListener("change", ()=>{mixerVolumeChange(newUserId)});
       channelVolumeInput.addEventListener("focus", ()=>{
         channelVolumeInput.classList.add("editing");
@@ -689,7 +689,7 @@ function update_active_users(user_summary, server_sample_rate, imLeading, n_user
       consoleChannels.set(newUserId, consoleChannel);
     }
   }
-  
+
   for (var i = 0; i < mic_volume_inputs.length; i++) {
 
     const name = mic_volume_inputs[i][0];
@@ -716,7 +716,7 @@ function update_active_users(user_summary, server_sample_rate, imLeading, n_user
       }
     }
     else {
-      channelVolumeInput.value = vol; 
+      channelVolumeInput.value = vol;
     }
 
 
@@ -818,7 +818,7 @@ async function start_singing() {
 
   // XXX: these event listeners will keep the object alive, plausibly, which could be bad if we do multiple songs?
   singer_client.addEventListener("diagnosticChange", () => {
-    console.info("DIAG:", singer_client.diagnostics);
+    console.debug("DIAG:", singer_client.diagnostics);
 
     window.clientTotalTime.value = singer_client.diagnostics.client_total_time;
     window.clientReadSlippage.value = singer_client.diagnostics.client_read_slippage;
@@ -852,8 +852,8 @@ async function start_singing() {
     var server_bpr = metadata["bpr"];
     var n_connected_users = metadata["n_connected_users"] || 0;
 
-    var imLeading = metadata["x_imLeading"];  // Hacky backwards-compat fix
-
+    var imLeading = metadata.leader && myUserid == metadata.leader;
+    console.debug("leader", metadata.leader, "me", myUserid, "iml", imLeading);
     update_active_users(user_summary, server_sample_rate, imLeading, n_connected_users);
 
     // XXX: needs to be reimplemented in terms of alarms / marks
@@ -880,8 +880,8 @@ async function start_singing() {
       window.bpr.value = server_bpr;
     }
     if (window.enableMixingConsole.checked) {
-      singer_client.x_send_metadata("mixer", 1,/*append=*/ false);
-    } 
+      singer_client.x_send_metadata("mixer", 1);
+    }
 
     if (delay_seconds) {
       if (delay_seconds > 0) {
@@ -983,7 +983,7 @@ async function start(spectatorMode=false) {
   await bucket_ctx.start_bucket();
 
   if (spectatorMode) {
-    enableSpectatorMode(); 
+    enableSpectatorMode();
   } else if (!disableLatencyMeasurement.checked) {
     do_latency_calibration();
     switch_app_state(APP_CALIBRATING_LATENCY);

--- a/html/index.html
+++ b/html/index.html
@@ -179,7 +179,7 @@ input.edited {
   background-color: yellow;
 }
 
-</style> 
+</style>
 
 <link rel=stylesheet href=lyrics.css>
 </head>
@@ -511,7 +511,7 @@ Beats Per Repeat (for rounds): <input type=text id=bpr></input>
     </select>
   <br>
     Server path:
-    <input type=text id=serverPath value="api">
+    <input type=text id=serverPath value="/api">
   <br>
     <div id=clickParams>(Clicks BPM if selected: <input type=text id=clickBPM value=60>)</div>
     <div id=eventTest>

--- a/html/net.js
+++ b/html/net.js
@@ -282,7 +282,7 @@ export async function query_server_clock(target_url) {
 
 var xhrs_inflight = 0;
 export async function samples_to_server(outdata, target_url, send_metadata) {
-  console.log(send_metadata);
+  console.debug("samples_to_server send_metadata:", send_metadata);
   if (outdata === null) {
     outdata = new Uint8Array();
   }

--- a/server.py
+++ b/server.py
@@ -239,6 +239,9 @@ def populate_tracks() -> None:
 
 populate_tracks()
 
+def insert_event(evid, clock) -> None:
+    events[evid] = clock
+
 def calculate_server_clock():
     # Note: This will eventually create a precision problem for the JS
     #   clients, which are using floats. Specifically, at 44100 Hz, it will
@@ -629,8 +632,8 @@ def handle_post_(in_data, new_events, query_string, print_status) -> Tuple[Any, 
             # We use "last_request_clock" because that's the moment the track
             #   actually starts due to the way our clearing algorithm currently
             #   works. (... I think.)
-            sendall("backing_track_start_clock", state.last_request_clock)
-            sendall("backing_track_end_clock", state.last_request_clock + len(state.backing_track))
+            insert_event("backingTrackStart", state.last_request_clock)
+            insert_event("backingTrackEnd", state.last_request_clock + len(state.backing_track))
 
 
     if query_params.get("mark_stop_singing", None):
@@ -713,7 +716,7 @@ def handle_post_(in_data, new_events, query_string, print_status) -> Tuple[Any, 
             user.last_write_clock = client_write_clock
 
         for ev in new_events:
-            events[ev["evid"]] = ev["clock"]
+            insert_event(ev["evid"], ev["clock"])
 
         in_data *= user.scaled_mic_volume
 


### PR DESCRIPTION
Fix mark timing, remove some debug spew (and add some mark timing debug spew), remove trailing whitespace

also: filter marks to only fire once; remove a couple unrelated hacky things; make the server generate "real" marks for backing track start and stop, which are persistent for clients which join late (instead of transient metadata)