### PR TITLE
Move user summary to post body, and use a fixed-length binary encoding

### DIFF
--- a/html/demo.js
+++ b/html/demo.js
@@ -848,7 +848,7 @@ async function start_singing() {
     var {metadata} = e.detail;
 
     var queue_size = metadata["queue_size"];
-    var user_summary = metadata["user_summary"] || [];
+    var user_summary = metadata["user_summary"];
     var tracks = metadata["tracks"];
     var chats = metadata["chats"] || [];
     var delay_seconds = metadata["delay_seconds"];

--- a/html/demo.js
+++ b/html/demo.js
@@ -887,9 +887,7 @@ async function start_singing() {
     if (server_bpr) {
       window.bpr.value = server_bpr;
     }
-    if (window.enableMixingConsole.checked) {
-      singer_client.x_send_metadata("mixer", 1);
-    }
+    singer_client.x_send_metadata("user_summary", 1);
 
     if (delay_seconds) {
       if (delay_seconds > 0) {

--- a/html/net.js
+++ b/html/net.js
@@ -145,12 +145,55 @@ export class ServerConnection extends ServerConnectionBase {
       end: metadata.client_read_clock,
       length: metadata.n_samples,
     });
+
+    metadata.user_summary = [];
+
+    let data = response.data;
+    if (data.byteLength > 0) {
+      const users_in_summary =
+            new DataView(data).getUint16(0, /*littleEndian=*/false);
+      const utf8decoder = new TextDecoder();
+
+      let pos = 2;
+      for (var user_index = 0; user_index < users_in_summary;
+           user_index++) {
+        const userid = utf8decoder.decode(data.slice(pos, pos + 16));
+        pos += 16
+
+        let name = "<undecodable>";
+        try {
+          name = utf8decoder.decode(data.slice(pos, pos + 32));
+        } catch {}
+        pos += 32;
+
+        const mic_volume =
+              new DataView(data.slice(pos, pos + 4)).getFloat32(0);
+        pos += 4;
+
+        const rms_volume =
+              new DataView(data.slice(pos, pos + 4)).getFloat32(0);
+        pos += 4;
+
+        const delay =
+              new DataView(data.slice(pos, pos + 2)).getUint16(
+                0, /*littleEndian=*/false);
+        pos += 2;
+
+        console.log(userid, name, mic_volume, rms_volume, delay);
+        metadata.user_summary.push([delay, name, mic_volume, userid, rms_volume]);
+      }
+      data = data.slice(pos);
+    }
+
+    data = new Uint8Array(data)
+    console.log(data);
+
     this.receive_cb({
       epoch: this.app_epoch,
       metadata,
       chunk: new CompressedAudioChunk({
         interval: result_interval,
-        data: new Uint8Array(response.data)
+        data
       })
     });
   }

--- a/server.py
+++ b/server.py
@@ -14,11 +14,19 @@ import logging
 import wave
 import threading
 import datetime
-
+import struct
 
 from typing import Any, Dict, List, Tuple, Iterable
 
 logging.basicConfig(filename='server.log',level=logging.DEBUG)
+
+# big-endian
+# 16   userid: 16 bytes of utf8, '\0' padded
+# 32   name: 32 bytes of utf8, '\0' padded
+#  4   mic_volume: float32,
+#  4   rms_volume: float32
+#  2   delay: uint16
+BINARY_USER_CONFIG_FORMAT = struct.Struct(">16s32sffH")
 
 FRAME_SIZE = 128
 
@@ -417,7 +425,7 @@ def setup_monitoring(monitoring_userid, monitored_userid) -> None:
 
 def user_summary(requested_mixer) -> List[Any]:
     summary = []
-    if len(users)>8 and not requested_mixer:
+    if len(users) > 30 and not requested_mixer:
         return summary
     for userid, user in users.items():
         summary.append((
@@ -428,6 +436,39 @@ def user_summary(requested_mixer) -> List[Any]:
             user.rms_volume))
     summary.sort()
     return summary
+
+def summary_length(n_users_in_summary):
+    return 2 + BINARY_USER_CONFIG_FORMAT.size*n_users_in_summary
+
+def binary_user_summary(summary):
+    """
+    Encode the user summary compactly.
+
+    number of users: uint16
+    repeat:
+       BINARY_USER_CONFIG_FORMAT
+
+    Each user is 60 bytes, so 1000 users is ~50k.  We could be more
+    compact by requiring the user ID to be numeric and then coding it
+    as, say, uint32 (4 bytes).  We could also only send names if they
+    have changed.
+    """
+    binary_summaries = [struct.pack(">H", len(summary))]
+    for delay, name, mic_volume, userid, rms_volume in summary:
+        binary_summaries.append(
+            BINARY_USER_CONFIG_FORMAT.pack(
+                userid.encode('utf8'),
+                name.encode('utf8'),
+                mic_volume,
+                rms_volume,
+                delay))
+    resp = np.frombuffer(b"".join(binary_summaries), dtype=np.uint8)
+
+    if len(resp) != summary_length(len(summary)):
+        raise Exception("Data for %s users encoded to %s bytes, expected %s",
+                        len(summary), len(resp), summary_length(len(summary)))
+
+    return resp
 
 def write_metronome(clear_index, clear_samples):
     metronome_samples = np.zeros(clear_samples, np.float32)
@@ -622,6 +663,8 @@ def get_events_to_send() -> Any:
     return [{"evid": i[0], "clock": i[1]} for i in events.items()]
 
 def handle_post(in_data, query_string, print_status) -> Tuple[Any, str]:
+    in_data = in_data.view(dtype=np.float32)
+
     raw_params = {}
     # For some reason urllib can't handle the query_string being empty
     if query_string:
@@ -645,13 +688,14 @@ def handle_post(in_data, query_string, print_status) -> Tuple[Any, str]:
             "server_clock": server_clock,
             "server_sample_rate": SAMPLE_RATE,
             "last_request_clock": state.last_request_clock,
-            "user_summary": user_summary(requested_mixer),
             "n_connected_users": len(users),
             "queue_size": QUEUE_LENGTH / FRAME_SIZE, # in 128-sample frames
             "events": get_events_to_send(),
             "leader": state.leader,
         }
-        return np.zeros(0), json.dumps(x_audio_metadata)
+        return (
+            binary_user_summary(user_summary(requested_mixer)),
+            json.dumps(x_audio_metadata))
 
     # NOTE NOTE NOTE:
     # * All `clock` variables are measured in samples.
@@ -839,7 +883,6 @@ def handle_post(in_data, query_string, print_status) -> Tuple[Any, str]:
         "client_read_clock": client_read_clock,
         "client_write_clock": client_write_clock,
         "n_samples": n_samples,
-        "user_summary": user_summary(requested_mixer),
         "n_connected_users": len(users),
         "queue_size": QUEUE_LENGTH / FRAME_SIZE, # in 128-sample frames
         "events": get_events_to_send(),
@@ -857,6 +900,9 @@ def handle_post(in_data, query_string, print_status) -> Tuple[Any, str]:
     if print_status:
         maybe_print_status()
 
+    bin_summary = binary_user_summary(user_summary(requested_mixer))
+    if len(bin_summary) > 0:
+        data = np.append(bin_summary, data.view(dtype=np.uint8))
     return data, json.dumps(x_audio_metadata)
 
 def maybe_print_status() -> None:

--- a/shm.py
+++ b/shm.py
@@ -37,23 +37,24 @@ def server_turn(buf):
     return buf[0] == MESSAGE_TYPE_POST
 
 def encode_json_and_data(buf, json_raw, data, throw_exceptions):
+    data = data.view(dtype=np.uint8)
+    
     index = 1
 
     json_raw_bytes = json_raw.encode("utf-8")
-    data_uint8 = data.view(dtype=np.uint8)
 
     errormsg = None
     if len(json_raw_bytes) > MAX_JSON_LENGTH:
         errormsg = "json too long: %s" % len(json_raw_bytes)
-    elif len(data_uint8) > MAX_DATA_LENGTH:
-        errormsg = "data too long: %s" % len(data_uint8)
+    elif len(data) > MAX_DATA_LENGTH:
+        errormsg = "data too long: %s" % len(data)
 
     if errormsg:
         if throw_exceptions:
             raise Exception(errormsg)
         else:
             json_raw_bytes = json.dumps({"error": errormsg}).encode("utf-8")
-            data_uint8 = np.zeros(0, dtype=np.uint8)
+            data = np.zeros(0, dtype=np.uint8)
 
     buf[index : index + 2] = memoryview(struct.pack("H", len(json_raw_bytes)))
     index += 2
@@ -61,10 +62,10 @@ def encode_json_and_data(buf, json_raw, data, throw_exceptions):
     buf[index : index + len(json_raw_bytes)] = memoryview(json_raw_bytes)
     index += len(json_raw_bytes)
 
-    buf[index : index + 4] = memoryview(struct.pack("I", len(data_uint8)))
+    buf[index : index + 4] = memoryview(struct.pack("I", len(data)))
     index += 4
 
-    buf[index : index + len(data_uint8)] = data_uint8
+    buf[index : index + len(data)] = data
 
 def decode_json_and_data(buf):
     index = 1
@@ -84,7 +85,7 @@ def decode_json_and_data(buf):
     if data_length > MAX_DATA_LENGTH:
         raise Exception("bad data length %s" % data_length)
 
-    data = buf[index : index + data_length].view(np.float32)
+    data = buf[index : index + data_length].view(np.uint8)
 
     return json_raw, data
 
@@ -99,7 +100,7 @@ class ShmServer:
         except Exception as e:
             encode_json_and_data(buf, json.dumps(
                 {"error": str(e), "inner_bt": traceback.format_exc()}
-            ), np.zeros(0, dtype=np.float32), throw_exceptions=False)
+            ), np.zeros(0, dtype=np.uint8), throw_exceptions=False)
 
     @staticmethod
     def run(buffer_names):


### PR DESCRIPTION
Move user summary to post body, and use a fixed-length binary encoding

Only include the summary when specifically requested.

Fixes #84