### PR TITLE
Validate that userid fits as a uint64

### DIFF
--- a/html/demo.js
+++ b/html/demo.js
@@ -21,6 +21,7 @@ window.singer_client = null;
 
 console.info("Starting up");
 
+// Must fit in a uint64.
 const myUserid = Math.round(Math.random()*100000000000)
 
 function prettyTime(ms) {

--- a/server.py
+++ b/server.py
@@ -783,6 +783,10 @@ def handle_post(in_data, query_string, print_status, client_address=None) -> Tup
     query_params = clean_query_params(raw_params)
 
     userid = query_params.get("userid", None)
+    if userid is not None:
+        if int(userid) < 0 or int(userid) > 0xffff_ffff_ffff_ffff:
+            raise ValueError("Userid must be a uint64")
+
     server_clock = calculate_server_clock()
     requested_user_summary = query_params.get("user_summary", None)
 


### PR DESCRIPTION
I am planning to encode the user ID as binary in the user summary, so I want to make sure it will fit as a uint64

The only consumer outside of this repo today is ritual engine, which uses the (inadequate) range [0, 1e9-1] (https://github.com/dspeyer/ritualEngine/blob/master/widgets/BucketSinging.js#L104).  So this is compatible with ritual engine as is.