### PR TITLE
Add a 'worklet ready' handshake when starting up. (Fixes 'placeholderchunk' race condition error.)

### DIFF
--- a/html/audio-worklet.js
+++ b/html/audio-worklet.js
@@ -583,6 +583,10 @@ class Player extends AudioWorkletProcessor {
       this.play_buffer = new ClockedRingBuffer(15, this.client_slack, this.clock_reference, this.port);
 
       this.ready = true;
+      this.port.postMessage({
+        type: "ready",
+        cookie: msg.cookie,
+      });
       return;
     } else if (msg.type == "stop") {
       this.ready = false;


### PR DESCRIPTION
When we ask the worklet to start up, because requests to the worklet are
asynchronous, we can't be sure of whether the worklet has even received a
previous client's request to shut down yet. This means we may get messages
that were intended for a previous client.

We serialize this by adding a 'handshake': when we ask the worklet to start,
we wait to get a 'ready' message back, indicating that it has started, before
accepting messages from it.

This should eliminate the stop-start race, wherein we get messages intended
for a previous client that already stopped the worklet (but the worklet has
not yet processed the command to stop.)

We also add a "cookie" to identify a specific start request; this should
eliminate an even more obscure race (stop-start-stop-start, where the second
start races the worklet's processing of the first start.)