### PR TITLE
Rework audio mark callback system for 1:1 delivery

### DIFF
--- a/html/app.js
+++ b/html/app.js
@@ -776,6 +776,11 @@ export class SingerClient extends EventTarget {
       }));
     })
 
+    // New SingerClient == new song; clear out any stale marks from the previous song.
+    this.ctx.playerNode.port.postMessage({  // XXX invasive coupling
+        type: "clear_alarms",
+    });
+
     this.connect_();
 
     this.speakerMuted = speakerMuted;


### PR DESCRIPTION
Replaced the "read_callbacks" scheme, which had two issues:
- Would only fire a callback either when received (if past), or at the exact
  time it was due. Callbacks could be skipped if the clock jumped e.g. due to
  reconnection or bucket switch.
- In the current iteration, we kept the callbacks on the playback buffer
  object, which gets cleared whenever the audio clock jumps, losing future
  callbacks.

In its place, we have a list of callbacks by timestamp, kept in the
audioworklet Player object (not cleared when we stop and start, cleared
manually between songs).
- When we play a chunk of audio, we check whether we passed through any
  callbacks during that chunk. Since they are sorted we need only look at the
  first one.
- If for whatever reason we have callbacks lying around that should have fired
  already -- whether because of a disconnection, a bucket change, or whatever
  -- we will fire them the moment that we start playing audio after they
  should have fired.

Thus the idea is that we should get once-and-only-once delivery of events.