### PR TITLE
Video Call Support

### DIFF
--- a/html/demo.js
+++ b/html/demo.js
@@ -1066,7 +1066,7 @@ async function connect_camera() {
   camera_devices = camera_devices.filter(
     (device) => device.kind=='videoinput' && device.deviceId);
 
-  if (!camera_devices) {
+  if (!camera_devices.length) {
     window.noCameraFound.style.display = "block";
     window.cameraPreview.style.display = "none";
     window.nextCamera.style.display = "none";

--- a/html/demo.js
+++ b/html/demo.js
@@ -518,6 +518,31 @@ function switch_app_state(newstate) {
 }
 set_controls();
 
+// If the user has started interacting, and then has not interacted
+// for 15 minutes, refresh the page. This keeps users from staying
+// connected when they don't mean to, and keeps us from running up a
+// large Twilio bill.
+const INACTIVITY_TIMEOUT_S = 60*15;
+let last_active_ts = Date.now();
+function resetInactivityTimer() {
+  last_active_ts = Date.now();
+}
+setInterval(() => {
+  if (app_state != APP_TUTORIAL && app_state != APP_CHOOSE_CAMERA) {
+    // App is at least partially running.
+    if (Date.now() - last_active_ts > INACTIVITY_TIMEOUT_S*1000) {
+      window.location.reload();
+    }
+  }
+}, 30000 /* 30s */);
+
+window.addEventListener('scroll', resetInactivityTimer, true);
+document.addEventListener("touchmove", resetInactivityTimer);
+document.addEventListener("mousemove", resetInactivityTimer);
+document.addEventListener("mousedown", resetInactivityTimer);
+document.addEventListener("keydown", resetInactivityTimer);
+document.addEventListener("keypress", resetInactivityTimer);
+
 let in_lagmute_mode = false;
 function dismissLagmute() {
   in_lagmute_mode = false;

--- a/html/demo.js
+++ b/html/demo.js
@@ -576,9 +576,17 @@ function toggle_video() {
         publication.track.stop();
         publication.unpublish();
       });
+      if (myVideoDiv) {
+        document.getElementById('remote-media-div').removeChild(myVideoDiv);
+        myVideoDiv = null;
+      }
     } else {
       Twilio.Video.createLocalVideoTrack({width: 160}).then(localVideoTrack => {
         twilio_room.localParticipant.publishTrack(localVideoTrack);
+        myVideoDiv = localVideoTrack.attach();
+        document.getElementById('remote-media-div').insertAdjacentElement(
+          'afterbegin', myVideoDiv);
+        myVideoDiv.style.transform = 'scale(-1, 1)';
       }).then(publication => {
         console.log('Successfully unmuted your video:', publication);
       });
@@ -1030,7 +1038,7 @@ let in_song = false;
 let twilio_room = null;
 
 const activeTrackDivs = {};
-
+let myVideoDiv = null;
 function connect_twilio() {
   Twilio.Video.createLocalTracks({
     audio: true,
@@ -1038,7 +1046,9 @@ function connect_twilio() {
   }).then(tracks => {
     for (const track of tracks) {
       if (track.kind === "video") {
-        document.getElementById('remote-media-div').appendChild(track.attach());
+        myVideoDiv = track.attach();
+        document.getElementById('remote-media-div').appendChild(myVideoDiv);
+        myVideoDiv.style.transform = 'scale(-1, 1)';
         break;
       }
     }

--- a/html/demo.js
+++ b/html/demo.js
@@ -1063,8 +1063,7 @@ async function connect_camera() {
   switch_app_state(APP_CHOOSE_CAMERA);
 
   camera_devices = await navigator.mediaDevices.enumerateDevices();
-  camera_devices = camera_devices.filter(
-    (device) => device.kind=='videoinput' && device.deviceId);
+  camera_devices = camera_devices.filter((device) => device.kind == 'videoinput');
 
   if (!camera_devices.length) {
     window.noCameraFound.style.display = "block";
@@ -1085,13 +1084,23 @@ async function connect_camera() {
 }
 
 async function update_preview_camera() {
+  const video_options = {width: 160};
+
+  let have_permission = !!camera_devices[chosen_camera_index].deviceId;
+  if (have_permission) {
+    video_options.deviceId = {exact: camera_devices[chosen_camera_index].deviceId};
+  }
+
   twilio_tracks = await Twilio.Video.createLocalTracks({
     audio: true,
-    video:  {
-      deviceId: {exact: camera_devices[chosen_camera_index].deviceId},
-      width: 160
-    }
+    video: video_options
   });
+
+  if (!have_permission) {
+    camera_devices = await navigator.mediaDevices.enumerateDevices();
+    camera_devices = camera_devices.filter(
+      (device) => device.kind == 'videoinput' && device.deviceId);
+  }
 
   for (const track of twilio_tracks) {
     if (track.kind === "video") {

--- a/html/demo.js
+++ b/html/demo.js
@@ -1164,7 +1164,7 @@ async function start_singing() {
     var server_bpm = metadata["bpm"];
     var server_repeats = metadata["repeats"];
     var server_bpr = metadata["bpr"];
-    var n_connected_users = metadata["n_connected_users"] || 0;first_bucket_s
+    var n_connected_users = metadata["n_connected_users"] || 0;
 
     first_bucket_s = metadata["first_bucket"] || first_bucket_s;
 

--- a/html/index.html
+++ b/html/index.html
@@ -67,6 +67,9 @@
 #tutorial button {
   margin: 0.25em;
 }
+#chooseCamera {
+  display: none;
+}
 .headphoneAdvice,
 #q_headphones_present,
 #q_wired_headphones_available,
@@ -176,6 +179,9 @@ input.edited {
 }
 #remote-media-div {
   margin: 1em;
+}
+#remote-media-div > * {
+  width: 160px;
 }
 #remainderWindow > * {
   margin: 1em;
@@ -328,6 +334,9 @@ h1 {
 #lagmute, #spectatorMode {
   display: none;
   padding: 0.5em;
+}
+#noCameraFound {
+  display: none;
 }
 </style>
 
@@ -581,6 +590,15 @@ Google Calendar.
     <button class=dismiss_tutorial>Get Started</button>
   </div>
   </div>
+
+<div id=chooseCamera>
+<div id=noCameraFound>No camera found</div>
+<div id=cameraPreview><span>loading...</span></div>
+<p>
+<button id=nextCamera>Switch camera</button>
+<button id=chosenCamera>Use this camera</button>
+<button id=noCamera>Continue without camera</button>
+</div>
 
 <div id=nameSelector>
 

--- a/html/index.html
+++ b/html/index.html
@@ -333,6 +333,9 @@ h1 {
 <link rel="icon"
       type="image/png"
       href="https://www.jefftk.com/bucket-brigade-logo.png">
+
+<script src="//media.twiliocdn.com/sdk/js/video/releases/2.8.0/twilio-video.min.js"></script>
+
 </head>
 
 <div id=page>
@@ -723,6 +726,9 @@ value=100>
 
 <div>
 
+<div id="remote-media-div">
+</div>
+
 <div id=chooseLeaderInstructions>
 Talk to each other in chat and figure out who's going to lead the next
 song.  They should click the "Lead a Song" button.
@@ -777,6 +783,7 @@ User <i><span id=leaderName>...</span></i> is leading
   <div>
     <button disabled id=micToggleButton>mute mic</button>
     <button disabled id=speakerToggleButton>mute speaker</button>
+    <button disabled id=videoToggleButton>...</button>
     <div id=lagmute>You've been muted due to lag</div>
   </div>
 

--- a/html/index.html
+++ b/html/index.html
@@ -78,7 +78,7 @@
   display: none;
 }
 
-#startSingingCountdown {
+#startSingingCountdown, #stopSingingCountdown {
   display: none;
 }
 #countdown {
@@ -174,7 +174,9 @@ input.edited {
   border-radius: 0.25em;
   padding: 0.5em;
 }
-
+#remote-media-div {
+  margin: 1em;
+}
 #remainderWindow > * {
   margin: 1em;
 }
@@ -323,9 +325,9 @@ h1 {
   display: none;
 }
 
-#lagmute {
-  color: red;
+#lagmute, #spectatorMode {
   display: none;
+  padding: 0.5em;
 }
 </style>
 
@@ -730,7 +732,7 @@ value=100>
 </div>
 
 <div id=chooseLeaderInstructions>
-Talk to each other in chat and figure out who's going to lead the next
+Talk to each other and figure out who's going to lead the next
 song.  They should click the "Lead a Song" button.
 </div>
 
@@ -784,7 +786,9 @@ User <i><span id=leaderName>...</span></i> is leading
     <button disabled id=micToggleButton>mute mic</button>
     <button disabled id=speakerToggleButton>mute speaker</button>
     <button disabled id=videoToggleButton>...</button>
-    <div id=lagmute>You've been muted due to lag</div>
+    <div id=lagmute>Due to lag, your singing is not included
+      <button id=unlagmute>Try Again</button></div>
+    <div id=spectatorMode>As a spectator, your singing is not included</div>
   </div>
 
   <div>

--- a/html/index.html
+++ b/html/index.html
@@ -371,6 +371,8 @@ h1 {
     <h1>Bucket Brigade</h1>
     </div>
 
+    <a href="no-video-temp/">Non-Video Version (temporary)</a>
+
     <a target="_blank" href="recordings/">Recent Recordings</a>
 
     <a target="_blank" href="https://calendar.google.com/calendar/u/0/embed?src=gsc268k1lu78lbvfbhphdr0cs4@group.calendar.google.com">View Calendar</a>

--- a/html/index.html
+++ b/html/index.html
@@ -180,9 +180,6 @@ input.edited {
 #remote-media-div {
   margin: 1em;
 }
-#remote-media-div > * {
-  width: 160px;
-}
 #remainderWindow > * {
   margin: 1em;
 }
@@ -338,6 +335,22 @@ h1 {
 #noCameraFound {
   display: none;
 }
+.participant {
+  display: none;
+  background-color: white;
+  width: 160;
+  overflow: hidden;
+  min-height: 2em;
+  border-radius: 0.25em;
+  border: 1px solid #ccc;
+}
+.participantInfo {
+  margin: 0.25em;
+}
+.participant > video {
+  width: 160px;
+}
+
 </style>
 
 <link rel=stylesheet href=lyrics.css>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy==1.19.2
 opuslib==3.0.1
 SharedArray==3.2.1
 sentry-sdk==0.19.5
+twilio==6.50.1

--- a/server.py
+++ b/server.py
@@ -330,7 +330,7 @@ class User:
         token = AccessToken(secrets["twilio"]["account_sid"],
                             secrets["twilio"]["api_key"],
                             secrets["twilio"]["api_secret"],
-                            identity=self.name)
+                            identity=self.userid)
 
         # Create a Video grant and add to token
         video_grant = VideoGrant(room=TWILIO_ROOM)

--- a/server.py
+++ b/server.py
@@ -49,6 +49,21 @@ except Exception:
 
 SERVER_STARTUP_TIME = int(time.time())
 
+ENABLE_TWILIO = True
+TWILIO_ROOM = "BucketBrigade"
+SECRETS_FNAME = "secrets.json"
+
+secrets = {}
+if os.path.exists(SECRETS_FNAME):
+    with open(SECRETS_FNAME) as inf:
+        secrets = json.loads(inf.read())
+else:
+    ENABLE_TWILIO = False
+
+if ENABLE_TWILIO:
+    from twilio.jwt.access_token import AccessToken
+    from twilio.jwt.access_token.grants import VideoGrant
+
 class State():
     def __init__(self):
         self.reset()
@@ -311,6 +326,18 @@ class User:
         self.send("bpr", state.bpr)
         self.send("tracks", tracks)
 
+    def allocate_twilio_token(self):
+        token = AccessToken(secrets["twilio"]["account_sid"],
+                            secrets["twilio"]["api_key"],
+                            secrets["twilio"]["api_secret"],
+                            identity=self.name)
+
+        # Create a Video grant and add to token
+        video_grant = VideoGrant(room=TWILIO_ROOM)
+        token.add_grant(video_grant)
+
+        self.send("twilio_token", token.to_jwt())
+
     # XXX: Are we sure we do not need to clear any of the other state across reconnects???
     def flush(self) -> None:
         """Delete any state that shouldn't be persisted across reconnects"""
@@ -463,6 +490,8 @@ def update_users(userid, username, server_clock, client_read_clock) -> None:
     delay_samples = server_clock - client_read_clock
     if userid not in users:
         users[userid] = User(userid, username, server_clock, delay_samples)
+        if ENABLE_TWILIO:
+            users[userid].allocate_twilio_token()
 
     users[userid].last_heard_server_clock = server_clock
     users[userid].delay_samples = delay_samples


### PR DESCRIPTION
Use Twilio to run a video call in parallel with the singing

* The video call is audio+video
* It's muted while anyone is singing
* You can choose your camera, and the selection is remembered
* You can choose no camera
* It doesn't hide the videos during singing, though perhaps it should
* The button for muting the mic applies to both the video call and bucket brigade
* You can turn your camera on and off
* If you lose connectivity, your image should disappear after about half a minute, when Twilio times you out
* Kicks people off if they accidentally leave the tab open without interaction for 15min, so we don't run up a large bill on Twilio

Not implemented:

* The button for meeting the speaker only applies to bucket brigade

This could probably use some real world testing before prod.  It's live on https://www.jefftk.com/echo